### PR TITLE
Added cache mechanism due to double request from Apigility.

### DIFF
--- a/src/ZF/Apigility/Doctrine/Server/Paginator/Adapter/DoctrineOrmAdapter.php
+++ b/src/ZF/Apigility/Doctrine/Server/Paginator/Adapter/DoctrineOrmAdapter.php
@@ -12,6 +12,7 @@ use Zend\Paginator\Adapter\AdapterInterface;
  */
 class DoctrineOrmAdapter extends Paginator implements AdapterInterface
 {
+	public $cache = array();
     /**
      * @param $offset
      * @param $itemCountPerPage
@@ -19,9 +20,14 @@ class DoctrineOrmAdapter extends Paginator implements AdapterInterface
      * @return array
      */
     public function getItems($offset, $itemCountPerPage) {
-        $this->getQuery()->setFirstResult($offset);
+    	if(array_key_exists($offset, $this->cache) 
+    			&& array_key_exists($itemCountPerPage, $this->cache[$offset]) ) 
+    		return $this->cache[$offset][$itemCountPerPage];
+    	$this->getQuery()->setFirstResult($offset);
         $this->getQuery()->setMaxResults($itemCountPerPage);
-
-        return $this->getQuery()->getResult();
+        
+        if(!array_key_exists($offset, $this->cache)) $this->cache[$offset] = array();
+        $this->cache[$offset][$itemCountPerPage] =  $this->getQuery()->getResult();
+        return $this->cache[$offset][$itemCountPerPage];
     }
 }


### PR DESCRIPTION
The cache can be put in private instead of public. It is a hot patch and not a definitive fix, as Doctrine should be configured and called in a way that results are cached by Doctrine itself.
