### PR TITLE
"admin" URL/location doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ API Resources
 
 ***/admin/api/module[/:name]/doctrine[/:controller_service_name]***
 
-This is a Doctrine resource creation route like Apigility Rest `/admin/api/module[/:name]/rest[/:controller_service_name]`
+This is a Doctrine resource creation route like Apigility Rest `/apigility/api/module[/:name]/rest[/:controller_service_name]`
 
 POST Parameters
 ```json
@@ -37,7 +37,7 @@ POST Parameters
 ```
 
 
-***/admin/api/doctrine[/:object_manager_alias]/metadata[/:name]***
+***/apigility/api/doctrine[/:object_manager_alias]/metadata[/:name]***
 
 This will return metadata for the named entity which is a member of the
 named object manager.  Querying without a name will return all metadata


### PR DESCRIPTION
I noticed that "admin" doesn't exist anymore in Apigility v0.9, I hope I am right, else sorry for troubles.
I also noticed that "doctrine" is used in URLs instead of "rest", is that ok?
