### PR TITLE
Updating required version to ZF 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": ">=5.4",
-        "zendframework/zendframework": "dev-develop",
+        "zendframework/zendframework": "2.3.*",
         "zfcampus/zf-apigility": "dev-master",
         "zfcampus/zf-configuration": "dev-master",
 	"zfcampus/zf-apigility-doctrine-server": "dev-master"


### PR DESCRIPTION
ZF 2.3 was released so I guess it's safe to change require version to 2.3.*.
