### PR TITLE
Implement basic "zoom" functionality

### DIFF
--- a/src/Server/Delegator/HydrationDelegator.php
+++ b/src/Server/Delegator/HydrationDelegator.php
@@ -1,0 +1,45 @@
+<?php
+namespace ZF\Apigility\Doctrine\Server\Delegator;
+
+use Phpro\DoctrineHydrationModule\Hydrator\DoctrineHydrator;
+use Zend\ServiceManager\DelegatorFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZF\Apigility\Doctrine\Server\Hydrator\Strategy\CollectionExtract;
+
+class HydrationDelegator implements DelegatorFactoryInterface
+{
+    private $zoom = array();
+
+    /**
+     * A factory that creates delegates of a given hydrator
+     *
+     * @param ServiceLocatorInterface $serviceLocator the service locator which requested the service
+     * @param string $name the normalized service name
+     * @param string $requestedName the requested service name
+     * @param callable $callback the callback that is responsible for creating the service
+     *
+     * @return mixed
+     */
+    public function createDelegatorWithName(ServiceLocatorInterface $serviceLocator, $name, $requestedName, $callback)
+    {
+        $hydrator = call_user_func($callback);
+
+        if (!$hydrator instanceof DoctrineHydrator) {
+            throw new \InvalidArgumentException("Can't use zoom with a non-doctrine hydrator");
+        }
+
+        foreach ($this->zoom as $collectionName) {
+            if ($hydrator->getExtractService()->hasStrategy($collectionName)) {
+                $hydrator->getExtractService()->removeStrategy($collectionName);
+                $hydrator->getExtractService()->addStrategy($collectionName, new CollectionExtract());
+            }
+        }
+
+        return $hydrator;
+    }
+
+    public function setZoom(array $zoom)
+    {
+        $this->zoom = $zoom;
+    }
+}

--- a/src/Server/Resource/DoctrineResource.php
+++ b/src/Server/Resource/DoctrineResource.php
@@ -7,6 +7,7 @@ use DoctrineModule\Persistence\ProvidesObjectManager;
 use DoctrineModule\Stdlib\Hydrator;
 use ZF\Apigility\Doctrine\Server\Collection\Query;
 use Zend\Stdlib\Hydrator\HydratorInterface;
+use ZF\Apigility\Doctrine\Server\Resource\Query\FetchOrmQuery;
 use ZF\ApiProblem\ApiProblem;
 use ZF\Rest\AbstractResourceListener;
 use ZF\Hal\Collection;
@@ -129,25 +130,21 @@ class DoctrineResource extends AbstractResourceListener
      */
     public function fetch($id)
     {
-        /**
-         * Zoom would be a nice-to-have
-        $parameters = $this->getEvent()->getQueryParams()->toArray();
+        $objectManager = $this->getObjectManager();
 
-        if ($this->getEvent()->getRouteParam('zoom')) {
-            $parameters['zoom'] = $this->getEvent()->getRouteParam('zoom');
+        if (class_exists('\\Doctrine\\ORM\\EntityManager') && $objectManager instanceof \Doctrine\ORM\EntityManager) {
+            $parameters = $this->getEvent()->getQueryParams()->toArray();
+
+            $fetchQuery = new FetchOrmQuery();
+            $fetchQuery->setServiceLocator($this->getServiceManager());
+            $fetchQuery->setObjectManager($objectManager);
+
+            $query = $fetchQuery->createQuery($this->getEntityClass(), $id, $parameters);
+
+            return $query->getSingleResult();
+        } else {
+            return $this->getObjectManager()->find($this->getEntityClass(), $id);
         }
-
-        if (isset($parameters['zoom'])) {
-            foreach ($parameters['zoom'] as $collectionName) {
-                if ($this->getHydrator()->getExtractService()->hasStrategy($collectionName)) {
-                    $this->getHydrator()->getExtractService()->removeStrategy($collectionName);
-                    $this->getHydrator()->getExtractService()->addStrategy($collectionName, new CollectionExtract());
-                }
-            }
-        }
-        */
-
-        return $this->getObjectManager()->find($this->getEntityClass(), $id);
     }
 
     /**

--- a/src/Server/Resource/Query/ApigilityFetchQuery.php
+++ b/src/Server/Resource/Query/ApigilityFetchQuery.php
@@ -1,0 +1,10 @@
+<?php
+namespace ZF\Apigility\Doctrine\Server\Resource\Query;
+
+use DoctrineModule\Persistence\ObjectManagerAwareInterface;
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+
+interface ApigilityFetchQuery extends ServiceLocatorAwareInterface, ObjectManagerAwareInterface
+{
+    public function createQuery($entityClass, $id, $parameters);
+}

--- a/src/Server/Resource/Query/FetchOrmQuery.php
+++ b/src/Server/Resource/Query/FetchOrmQuery.php
@@ -1,0 +1,61 @@
+<?php
+namespace ZF\Apigility\Doctrine\Server\Resource\Query;
+
+use DoctrineModule\Persistence\ProvidesObjectManager;
+use Zend\ServiceManager\ServiceLocatorAwareTrait;
+use ZF\Apigility\Doctrine\Server\Delegator\HydrationDelegator;
+
+class FetchOrmQuery implements ApigilityFetchQuery
+{
+    use ServiceLocatorAwareTrait;
+    use ProvidesObjectManager;
+
+    public function createQuery($entityClass, $id, $parameters)
+    {
+        $queryBuilder = $this->getObjectManager()->createQueryBuilder();
+
+        $queryBuilder->select('row')
+            ->from($entityClass, 'row')
+            ->where('row = :id')
+            ->setParameter('id', $id);
+
+        if (isset($parameters['zoom'])) {
+            $metadata = $this->getObjectManager()->getClassMetadata($entityClass);
+            $zoomCount = 0;
+
+            foreach ($parameters['zoom'] as $key => $zoom) {
+                if (!$metadata->hasAssociation($zoom)) {
+                    unset($parameters['zoom'][$key]);
+                    continue;
+                }
+
+                $queryBuilder->leftJoin('row.' . $zoom, 'l' . $zoomCount);
+                $queryBuilder->add('select', 'l' . $zoomCount, true);
+
+                $zoomCount++;
+            }
+
+            $this->registerDelegator($entityClass, $parameters['zoom']);
+        }
+
+        $query = $queryBuilder->getQuery();
+
+        return $query;
+    }
+
+    private function registerDelegator($entityClass, $zoom)
+    {
+        $config = $this->getServiceLocator()->get('Config');
+
+        if (!isset($config['zf-hal']['metadata_map'][$entityClass])) {
+            return;
+        }
+
+        $hydrator = $config['zf-hal']['metadata_map'][$entityClass]['hydrator'];
+        $delegator = new HydrationDelegator();
+
+        $delegator->setZoom($zoom);
+
+        $this->getServiceLocator()->get('HydratorManager')->addDelegator($hydrator, $delegator);
+    }
+}


### PR DESCRIPTION
Bit of a WIP at the moment.

This implements the "zoom" functionality that was listed as a nice to have in the fetch function.

So what you can do is specify names of relationships in the zoom query parameter and these will be embedded in the response.

It does this by using a delegator factory to capture the creation of hydrators and force them to use the `CollectionExtract` strategy for the specified relationships. The relationships are also fetched using a left join for performance.

This is a WIP for the following reasons:

- Not familiar with ODM hence does not support it, if something similar could be supported anyway.
- No way to configure which relationships you'd like to have this functionality available on, just allows any relationship.
- Query is sub optimal since it can fetch more results in the query than may actually be included in the response.
- All possible child entities that could be fetched via the zoom functionality need to have a strategy configured on the reverse parent relationship to prevent infinite recursion.

Only just started working with apigility today so I'm not very familiar with exactly how everything works but hopefully I've not broken anything.