### PR TITLE
Improvement for patch method in DoctrineResource.php

### DIFF
--- a/src/Server/Resource/DoctrineResource.php
+++ b/src/Server/Resource/DoctrineResource.php
@@ -264,13 +264,10 @@ class DoctrineResource extends AbstractResourceListener
         }
             // @codeCoverageIgnoreEnd
 
-        // Load full data:
         $hydrator = $this->getHydrator();
-        $originalData = $hydrator->extract($entity);
-        $patchedData = array_merge($originalData, (array) $data);
-
+        
         // Hydrate entity
-        $hydrator->hydrate($patchedData, $entity);
+        $hydrator->hydrate((array) $data, $entity);
 
         $this->triggerDoctrineEvent(DoctrineResourceEvent::EVENT_PATCH_PRE, $entity);
         $this->getObjectManager()->flush();


### PR DESCRIPTION
I don't understand why the full entity data is put in an array. With a patch you want to touch as minimal as possible. So I think the change of this pull request is sufficient/better?
