### PR TITLE
Fix #115 - Orm\Between filter resets parameters

### DIFF
--- a/src/Server/Collection/Filter/ORM/Between.php
+++ b/src/Server/Collection/Filter/ORM/Between.php
@@ -30,6 +30,7 @@ class Between extends AbstractFilter
         $toParameter = uniqid('a');
 
         $queryBuilder->$queryType($queryBuilder->expr()->between('row.' . $option['field'], ":$fromParameter", ":$toParameter"));
-        $queryBuilder->setParameters(array($fromParameter => $from, $toParameter => $to));
+        $queryBuilder->setParameter($fromParameter, $from);
+        $queryBuilder->setParameter($toParameter, $to);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/zfcampus/zf-apigility-doctrine/issues/115

`QueryBuilder::setParameters()` replaces the parameters collection instead of merging it with the passed traversable.
