### PR TITLE
Added EVENT_FETCH_ALL_PRE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Apigility for Doctrine
 ==============================
 
-[![Build status](https://api.travis-ci.org/zfcampus/zf-apigility-doctrine.svg)](http://travis-ci.org/zfcampus/zf-apigility-doctrine) 
+[![Build status](https://api.travis-ci.org/zfcampus/zf-apigility-doctrine.svg)](http://travis-ci.org/zfcampus/zf-apigility-doctrine)
 
 This module provides the classes for integrating Doctrine with Apigility.
 
@@ -63,10 +63,12 @@ Custom Events
 =============
 It is possible to hook in on specific doctrine events of the type `DoctrineResourceEvent`.
 This way, it is possible to alter the doctrine entities or collections before or after a specific action is performed.
+The EVENT_FETCH_ALL_PRE works on the Query Builder from the fetch all query.  This allows you to modify the Query Builder before a fetch is performed.
 
 A list of all supported events:
 ```
 EVENT_FETCH_POST = 'fetch.post';
+EVENT_FETCH_ALL_PRE = 'fetch-all.pre';
 EVENT_FETCH_ALL_POST = 'fetch-all.post';
 EVENT_CREATE_PRE = 'create.pre';
 EVENT_CREATE_POST = 'create.post';
@@ -119,7 +121,7 @@ For instance, a route of ```/api/artist/:artist_id/album/:album_id``` mapped to 
 entity will filter the Album for field names.  So, given an album with id, name, and artist
 fields the album_id matches to the resoruce configuration and will be queried by key
 and the artist is a field on album and will be queried by criteria so the final query
-would be 
+would be
 
 ```
 $objectManager->getRepository('Album')->findOneBy(

--- a/src/Server/Event/DoctrineResourceEvent.php
+++ b/src/Server/Event/DoctrineResourceEvent.php
@@ -12,8 +12,8 @@ use ZF\Rest\ResourceEvent;
  */
 class DoctrineResourceEvent extends Event
 {
-
     const EVENT_FETCH_POST = 'fetch.post';
+    const EVENT_FETCH_ALL_PRE = 'fetch-all.pre';
     const EVENT_FETCH_ALL_POST = 'fetch-all.post';
     const EVENT_CREATE_PRE = 'create.pre';
     const EVENT_CREATE_POST = 'create.post';
@@ -40,11 +40,36 @@ class DoctrineResourceEvent extends Event
     protected $collection;
 
     /**
+     * @var Doctrine\ORM\QueryBuilder
+     */
+    protected $queryBuilder;
+
+    /**
+     * @param Doctrine\ORM\QueryBuilder $queryBuilder
+     */
+    public function setQueryBuilder($queryBuilder)
+    {
+        $this->queryBuilder = $queryBuilder;
+
+        return $this;
+    }
+
+    /**
+     * @return Doctrine\ORM\QueryBuilder
+     */
+    public function getQueryBuilder()
+    {
+        return $this->queryBuilder;
+    }
+
+    /**
      * @param mixed $collection
      */
     public function setCollection($collection)
     {
         $this->collection = $collection;
+
+        return $this;
     }
 
     /**
@@ -61,6 +86,8 @@ class DoctrineResourceEvent extends Event
     public function setEntity($entity)
     {
         $this->entity = $entity;
+
+        return $this;
     }
 
     /**
@@ -77,6 +104,8 @@ class DoctrineResourceEvent extends Event
     public function setResourceEvent($resourceEvent)
     {
         $this->resourceEvent = $resourceEvent;
+
+        return $this;
     }
 
     /**

--- a/src/Server/Resource/DoctrineResource.php
+++ b/src/Server/Resource/DoctrineResource.php
@@ -262,6 +262,13 @@ class DoctrineResource extends AbstractResourceListener
         }
             // @codeCoverageIgnoreEnd
 
+        // Run fetch all pre with query builder
+        $event = new DoctrineResourceEvent(DoctrineResourceEvent::EVENT_FETCH_ALL_PRE, $this);
+        $event->setQueryBuilder($queryBuilder);
+        $event->setResourceEvent($this->getEvent());
+        $eventManager = $this->getEventManager();
+        $response = $eventManager->trigger($event);
+
         $adapter = $fetchAllQuery->getPaginatedQuery($queryBuilder);
         $reflection = new \ReflectionClass($this->getCollectionClass());
         $collection = $reflection->newInstance($adapter);
@@ -274,7 +281,7 @@ class DoctrineResource extends AbstractResourceListener
             function ($e) use ($fetchAllQuery, $entityClass, $data) {
                 $halCollection = $e->getParam('collection');
                 $collection = $halCollection->getCollection();
-                
+
                 $collection->setItemCountPerPage($halCollection->getPageSize());
                 $collection->setCurrentPageNumber($halCollection->getPage());
 

--- a/test/src/Server/ODM/CRUD/CRUDTest.php
+++ b/test/src/Server/ODM/CRUD/CRUDTest.php
@@ -107,7 +107,7 @@ class CRUDTest extends \Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestC
         $body = json_decode($this->getResponse()->getBody(), true);
         $this->assertEquals(200, $this->getResponseStatusCode());
         $this->assertEquals(2, sizeof($body['_embedded']['meta']));
-        $this->validateTriggeredEvents([DoctrineResourceEvent::EVENT_FETCH_ALL_POST]);
+        $this->validateTriggeredEvents([DoctrineResourceEvent::EVENT_FETCH_ALL_PRE, DoctrineResourceEvent::EVENT_FETCH_ALL_POST]);
     }
 /*
     public function testPatch()

--- a/test/src/Server/ORM/CRUD/CRUDTest.php
+++ b/test/src/Server/ORM/CRUD/CRUDTest.php
@@ -100,7 +100,7 @@ class CRUDTest extends \Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestC
         $body = json_decode($this->getResponse()->getBody(), true);
         $this->assertEquals(200, $this->getResponseStatusCode());
         $this->assertEquals(2, sizeof($body['_embedded']['artist']));
-        $this->validateTriggeredEvents([DoctrineResourceEvent::EVENT_FETCH_ALL_POST]);
+        $this->validateTriggeredEvents([DoctrineResourceEvent::EVENT_FETCH_ALL_PRE, DoctrineResourceEvent::EVENT_FETCH_ALL_POST]);
     }
 
     public function testPatch()


### PR DESCRIPTION
This adds an event to modify the query builder before a fetch all.  This will allow zf-doctrine-querybuilder-filter to hook in and add additional filters to a query builder.
