### PR TITLE
[WIP] Cleanly remove orderBy and query for filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ for the object manager.
 
 ***/apigility/api/module[/:name]/doctrine[/:controller_service_name]***
 
-This is a Doctrine resource creation route like Apigility Rest `/apigility/api/module[/:name]/rest[/:controller_service_name]`
+This is a Doctrine resource creation route _like_ Apigility Rest `/apigility/api/module[/:name]/rest[/:controller_service_name]`
 POST Parameters:
 
 ```json
@@ -52,7 +52,6 @@ POST Parameters:
 }
 ```
 
-
 Hydrating Entities by Value or Reference
 ----------------------------------------
 
@@ -61,6 +60,7 @@ By default the admin tool hydrates entities by reference by setting `$config['do
 
 Custom Events
 =============
+
 It is possible to hook in on specific doctrine events of the type `DoctrineResourceEvent`.
 This way, it is possible to alter the doctrine entities or collections before or after a specific action is performed.
 The EVENT_FETCH_ALL_PRE works on the Query Builder from the fetch all query.  This allows you to modify the Query Builder before a fetch is performed.
@@ -133,20 +133,6 @@ $objectManager->getRepository('Album')->findOneBy(
 The album(_id) is not a field on the Album entity and will be ignored.
 
 
-Collections
-===========
-
-The API created with this library implements full featured and paginated
-collection resources.  A collection is returned from a GET call to an entity endpoint without
-specifying the id.  e.g. ```GET /api/resource```
-
-Reserved GET variables
-
-```
-    orderBy
-    query
-```
-
 Providing a base query
 ----------------------
 
@@ -177,20 +163,3 @@ When the query provider is registered, you have to attach it to the doctrine-con
     ),
 ),
 ```
-
-Sorting Collections
--------------------
-
-Sort by columnOne ascending
-
-```
-    /api/user_data?orderBy%5BcolumnOne%5D=ASC
-```
-
-Sort by columnOne ascending then columnTwo decending
-
-```
-    /api/user_data?orderBy%5BcolumnOne%5D=ASC&orderBy%5BcolumnTwo%5D=DESC
-```
-
-

--- a/src/Admin/Model/DoctrineRestServiceModel.php
+++ b/src/Admin/Model/DoctrineRestServiceModel.php
@@ -706,7 +706,7 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface, ServiceMan
                 'collection_name'            => $details->collectionName,
                 'entity_http_methods'        => $details->entityHttpMethods,
                 'collection_http_methods'    => $details->collectionHttpMethods,
-                'collection_query_whitelist'    => ($details->collectionQueryWhitelist) ?: array('query', 'orderBy'),
+                'collection_query_whitelist'    => ($details->collectionQueryWhitelist) ?: array(),
                 'page_size'                  => $details->pageSize,
                 'page_size_param'            => $details->pageSizeParam,
                 'entity_class'               => $details->entityClass,

--- a/src/Server/Collection/Query/FetchAllOdmQuery.php
+++ b/src/Server/Collection/Query/FetchAllOdmQuery.php
@@ -20,18 +20,6 @@ class FetchAllOdmQuery implements ApigilityFetchAllQuery
         $queryBuilder = $this->getObjectManager()->createQueryBuilder();
         $queryBuilder->find($entityClass);
 
-        // Orderby
-        if (!isset($parameters['orderBy'])) {
-            $parameters['orderBy'] = array('id' => 'asc');
-        }
-        foreach ($parameters['orderBy'] as $fieldName => $sort) {
-            $queryBuilder->sort($fieldName, $sort);
-        }
-
-        // Get metadata for type casting
-        $cmf = $this->getObjectManager()->getMetadataFactory();
-        $metadata = (array) $cmf->getMetadataFor($entityClass);
-
         return $queryBuilder;
     }
 

--- a/src/Server/Collection/Query/FetchAllOrmQuery.php
+++ b/src/Server/Collection/Query/FetchAllOrmQuery.php
@@ -32,18 +32,6 @@ class FetchAllOrmQuery implements ObjectManagerAwareInterface, ApigilityFetchAll
         $queryBuilder->select('row')
             ->from($entityClass, 'row');
 
-        // Get metadata for type casting
-        $cmf = $this->getObjectManager()->getMetadataFactory();
-        $entityMetaData = $cmf->getMetadataFor($entityClass);
-        $metadata = (array) $entityMetaData;
-        // Orderby
-        if (!isset($parameters['orderBy'])) {
-            $parameters['orderBy'] = array($entityMetaData->getIdentifier()[0] => 'asc');
-        }
-        foreach ($parameters['orderBy'] as $fieldName => $sort) {
-            $queryBuilder->addOrderBy("row.$fieldName", $sort);
-        }
-
         return $queryBuilder;
     }
 

--- a/src/Server/Controller/RpcController.php
+++ b/src/Server/Controller/RpcController.php
@@ -50,8 +50,7 @@ abstract class RpcController extends AbstractActionController
             }
         }
 
-        $query = (array) $this->getRequest()->getQuery()->get('query');
-        $orderBy = $this->getRequest()->getQuery()->get('orderBy');
+        $query = array();
 
         if ($childId) {
             // Verify child is a child of parent
@@ -81,10 +80,7 @@ abstract class RpcController extends AbstractActionController
             $query[] = array('type' => 'eq', 'field' => $sourceField, 'value' => $parentId);
 
             $this->getRequest()->setMethod('GET');
-            $hal = $this->forward()->dispatch($controllerName, array(
-                'query' => $query,
-                'orderBy' => $orderBy,
-            ));
+            $hal = $this->forward()->dispatch($controllerName, array());
             $renderer = $this->getServiceLocator()->get('ZF\Hal\JsonRenderer');
             $data = json_decode($renderer->render($hal), true);
 

--- a/test/src/Server/ODM/CRUD/CRUDTest.php
+++ b/test/src/Server/ODM/CRUD/CRUDTest.php
@@ -108,7 +108,7 @@ class CRUDTest extends \Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestC
         ));
         $this->getRequest()->setMethod(Request::METHOD_GET);
         $this->getRequest()->setContent(null);
-        $this->dispatch('/test/meta?orderBy%5Bname%5D=ASC');
+        $this->dispatch('/test/meta');
         $body = json_decode($this->getResponse()->getBody(), true);
         $this->assertEquals(200, $this->getResponseStatusCode());
         $this->assertEquals(2, count($body['_embedded']['meta']));

--- a/test/src/Server/ORM/CRUD/CRUDTest.php
+++ b/test/src/Server/ORM/CRUD/CRUDTest.php
@@ -99,7 +99,7 @@ class CRUDTest extends \Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestC
         ));
         $this->getRequest()->setMethod(Request::METHOD_GET);
         $this->getRequest()->setContent(null);
-        $this->dispatch('/test/artist?orderBy%5Bname%5D=ASC');
+        $this->dispatch('/test/artist');
         $body = json_decode($this->getResponse()->getBody(), true);
         $this->assertEquals(200, $this->getResponseStatusCode());
         $this->assertEquals(2, count($body['_embedded']['artist']));


### PR DESCRIPTION
orderBy was still handled and $_GET['query'] was reserved for filters.  Both of these have been removed.  

This PR should be merged after https://github.com/phpro/zf-doctrine-hydration-module/pull/15 and https://github.com/zfcampus/zf-doctrine-querybuilder-filter/pull/1