### PR TITLE
Hotfix/entity identifier name

### DIFF
--- a/docs/RELEASE-0.3.2.md
+++ b/docs/RELEASE-0.3.2.md
@@ -21,7 +21,8 @@ class UserAlbumCreateFilter extends DefaultCreateFilter
             return $validate;
         }
 
-        $request = $this->getServiceLocator()->getServiceLocator()->get('Request')->getQuery()->toArray();
+        $request = $event->getRequest()->getQuery()->toArray();
+
         $identity = $event->getIdentity()->getAuthenticationIdentity();
         $data->user = $identity['user_id'];
 

--- a/docs/RELEASE-0.3.3.md
+++ b/docs/RELEASE-0.3.3.md
@@ -1,0 +1,27 @@
+# Allow Non-Doctrine Entity Identifier Fields as Resource Identifier(s)
+
+When finding the target entity the identifiers were limited to the entity metadata identifier fields.  This change makes the API much more flexible by allowing standard field(s) as the identifier.
+
+```
+    'zf-rest' => array(
+        'ZFTestApigilityDbApi\\V1\\Rest\\ArtistByName\\Controller' => array(
+            'listener' => 'ZFTestApigilityDbApi\\V1\\Rest\\ArtistByName\\ArtistByNameResource',
+            'route_name' => 'zf-test-apigility-db-api.rest.doctrine.artist-by-name',
+            'route_identifier_name' => 'artist_name',
+            'entity_identifier_name' => 'name',
+            'collection_name' => 'artist_by_name',
+            'entity_http_methods' => array(
+```
+
+This configuration shows the ```entity_identifier_name``` as 'name'.  
+
+# Multiple keys
+
+With this change you can use any combination of fields as your identifer.  For instance you can use 
+```
+...
+'entity_identifer_name' => 'email.shop'
+```
+
+Using the multi key delimiter on the resource, defaulted to '.' you may then make an api call like ```/api/user/useremailaddress.usershop``` where neither field is an identifier.
+

--- a/src/Server/Query/CreateFilter/AbstractCreateFilter.php
+++ b/src/Server/Query/CreateFilter/AbstractCreateFilter.php
@@ -87,7 +87,7 @@ abstract class AbstractCreateFilter implements ObjectManagerAwareInterface, Quer
         if (! $this->getOAuth2Server()->verifyResourceRequest(
             OAuth2Request::createFromGlobals(),
             $response = null,
-            $scope = null
+            $scope
         )) {
             $error = $this->getOAuth2Server()->getResponse();
             $parameters = $error->getParameters();

--- a/src/Server/Query/Provider/AbstractQueryProvider.php
+++ b/src/Server/Query/Provider/AbstractQueryProvider.php
@@ -119,7 +119,7 @@ abstract class AbstractQueryProvider implements ObjectManagerAwareInterface, Que
         if (! $this->getOAuth2Server()->verifyResourceRequest(
             OAuth2Request::createFromGlobals(),
             $response = null,
-            $scope = null
+            $scope
         )) {
             $error = $this->getOAuth2Server()->getResponse();
             $parameters = $error->getParameters();

--- a/src/Server/Resource/DoctrineResource.php
+++ b/src/Server/Resource/DoctrineResource.php
@@ -610,12 +610,10 @@ class DoctrineResource extends AbstractResourceListener implements
      */
     protected function findEntity($id, $method)
     {
-        $classMetaData = $this->getObjectManager()->getClassMetadata($this->getEntityClass());
-        $identifierFieldNames = $classMetaData->getIdentifierFieldNames();
-
         // Match identiy identifier name(s) with id(s)
         $ids = explode($this->getMultiKeyDelimiter(), $id);
         $keys = explode($this->getMultiKeyDelimiter(), $this->getEntityIdentifierName());
+        $criteria = array();
 
         if (sizeof($ids) != sizeof($keys)) {
             return new ApiProblem(
@@ -631,6 +629,7 @@ class DoctrineResource extends AbstractResourceListener implements
             $criteria[$identifier] = $ids[$index];
         }
 
+        $classMetaData = $this->getObjectManager()->getClassMetadata($this->getEntityClass());
         $routeMatch = $this->getEvent()->getRouteMatch();
         $associationMappings = $classMetaData->getAssociationNames();
         $fieldNames = $classMetaData->getFieldNames();

--- a/src/Server/Resource/DoctrineResource.php
+++ b/src/Server/Resource/DoctrineResource.php
@@ -613,27 +613,22 @@ class DoctrineResource extends AbstractResourceListener implements
         $classMetaData = $this->getObjectManager()->getClassMetadata($this->getEntityClass());
         $identifierFieldNames = $classMetaData->getIdentifierFieldNames();
 
-        $criteria = array();
+        // Match identiy identifier name(s) with id(s)
+        $ids = explode($this->getMultiKeyDelimiter(), $id);
+        $keys = explode($this->getMultiKeyDelimiter(), $this->getEntityIdentifierName());
 
-        // Check if ID is a composite ID
-        if (strpos($id, $this->getMultiKeyDelimiter()) !== false) {
-            $compositeIdParts = explode($this->getMultiKeyDelimiter(), $id);
+        if (sizeof($ids) != sizeof($keys)) {
+            return new ApiProblem(
+                500,
+                'Invalid multi identifier count.  '
+                . sizeof($ids)
+                . ' must equal '
+                . sizeof($keys)
+            );
+        }
 
-            if (sizeof($compositeIdParts) != sizeof($identifierFieldNames)) {
-                return new ApiProblem(
-                    500,
-                    'Invalid multi identifier count.  '
-                    . sizeof($compositeIdParts)
-                    . ' must equal '
-                    . sizeof($identifierFieldNames)
-                );
-            }
-
-            foreach ($compositeIdParts as $index => $compositeIdPart) {
-                $criteria[$identifierFieldNames[$index]] = $compositeIdPart;
-            }
-        } else {
-            $criteria[$identifierFieldNames[0]] = $id;
+        foreach ($keys as $index => $identifier) {
+            $criteria[$identifier] = $ids[$index];
         }
 
         $routeMatch = $this->getEvent()->getRouteMatch();

--- a/test/src/Server/ORM/CRUD/CRUDTest.php
+++ b/test/src/Server/ORM/CRUD/CRUDTest.php
@@ -123,6 +123,20 @@ class CRUDTest extends \Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestC
         $this->assertEquals('ArtistTwo', $body['name']);
         $this->validateTriggeredEvents(array(DoctrineResourceEvent::EVENT_FETCH_POST));
 
+        // Test fetch() of resource with non-primary key identifier
+        $this->getRequest()->getHeaders()->addHeaders(
+            array(
+            'Accept' => 'application/json',
+            )
+        );
+        $this->getRequest()->setMethod(Request::METHOD_GET);
+        $this->getRequest()->setContent(null);
+        $this->dispatch('/test/artist-by-name/' . $artist->getName());
+        $body = json_decode($this->getResponse()->getBody(), true);
+
+        $this->assertEquals(200, $this->getResponseStatusCode());
+        $this->assertEquals('ArtistTwo', $body['name']);
+
         // Test fetch() with listener that returns ApiProblem
         $this->reset();
         $this->setUp();

--- a/test/src/Server/ORM/Setup/ApigilityTest.php
+++ b/test/src/Server/ORM/Setup/ApigilityTest.php
@@ -44,6 +44,18 @@ class ApigilityTest extends \Zend\Test\PHPUnit\Controller\AbstractHttpController
             ),
         );
 
+        $artistResourceDefinitionWithNonKeyIdentifer = array(
+            "objectManager"=> "doctrine.entitymanager.orm_default",
+            "serviceName" => "ArtistByName",
+            "entityClass" => "ZFTestApigilityDb\\Entity\\Artist",
+            "routeIdentifierName" => "artist_name",
+            "entityIdentifierName" => "name",
+            "routeMatch" => "/test/artist-by-name",
+            "collectionHttpMethods" => array(
+                0 => 'GET',
+            ),
+        );
+
         $albumResourceDefinition = array(
             "objectManager"=> "doctrine.entitymanager.orm_default",
             "serviceName" => "Album",
@@ -60,6 +72,7 @@ class ApigilityTest extends \Zend\Test\PHPUnit\Controller\AbstractHttpController
 
         $resource->setModuleName('ZFTestApigilityDbApi');
         $artistEntity = $resource->create($artistResourceDefinition);
+        $artistEntity = $resource->create($artistResourceDefinitionWithNonKeyIdentifer);
         $albumEntity = $resource->create($albumResourceDefinition);
 
         $this->assertInstanceOf('ZF\Apigility\Doctrine\Admin\Model\DoctrineRestServiceEntity', $artistEntity);


### PR DESCRIPTION
https://github.com/zfcampus/zf-apigility-doctrine/issues/154 discusses using a field which is not an entity metadata identifier field name as the resource identifier for an entity.  

This hotfix replaces the metadata lookup and trusts the config identifier and id passed to the resource.