### PR TITLE
Exchanged getSingleResult with getOneOrNullResult

### DIFF
--- a/src/Server/Resource/DoctrineResource.php
+++ b/src/Server/Resource/DoctrineResource.php
@@ -673,11 +673,7 @@ class DoctrineResource extends AbstractResourceListener implements
             }
         }
 
-        try {
-            $entity = $queryBuilder->getQuery()->getSingleResult();
-        } catch (NoResultException $e) {
-            $entity = null;
-        }
+        $entity = $queryBuilder->getQuery()->getOneOrNullResult();
 
         if (!$entity) {
             $entity = new ApiProblem(404, 'Entity was not found');


### PR DESCRIPTION
Simplified the code by changing the method `getSingleResult` with `getOneOrNullResult`. Now the clause that checks for a `NoResultException` can be dropped and the returned result will be the same (`null` an entity object or a `NonUniqueResultException`).