### PR TITLE
fix missing field service_name in configuration

### DIFF
--- a/src/Admin/Model/DoctrineRestServiceEntity.php
+++ b/src/Admin/Model/DoctrineRestServiceEntity.php
@@ -60,6 +60,9 @@ class DoctrineRestServiceEntity extends RestServiceEntity implements ArraySerial
                 case 'usegeneratedhydrator':
                     $this->useGeneratedHydrator = $value;
                     break;
+                case 'servicename':
+                    $this->serviceName = $value;
+                    break;
             }
         }
     }
@@ -72,6 +75,7 @@ class DoctrineRestServiceEntity extends RestServiceEntity implements ArraySerial
         $data['by_value'] = $this->byValue;
         $data['strategies'] = $this->hydratorStrategies;
         $data['use_generated_hydrator'] = $this->useGeneratedHydrator;
+        $data['service_name'] = $this->serviceName;
 
         return $data;
     }

--- a/src/Admin/Model/DoctrineRestServiceModel.php
+++ b/src/Admin/Model/DoctrineRestServiceModel.php
@@ -435,6 +435,10 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface, ServiceMan
             $details->collectionClass:
             $this->createCollectionClass($resourceName);
 
+        $serviceName = ($details->serviceName) ?
+            $details->serviceName:
+            $resourceName;
+
         if (!$entityClass = $details->entityClass or !class_exists($details->entityClass)) {
             // @codeCoverageIgnoreStart
             throw new \Exception('entityClass is required and must exist');
@@ -457,6 +461,7 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface, ServiceMan
 
         $entity->exchangeArray(
             array(
+            'service_name'            => $serviceName,
             'collection_class'        => $collectionClass,
             'controller_service_name' => $controllerService,
             'entity_class'            => $entityClass,
@@ -786,6 +791,7 @@ class DoctrineRestServiceModel implements EventManagerAwareInterface, ServiceMan
                 'page_size_param'            => $details->pageSizeParam,
                 'entity_class'               => $details->entityClass,
                 'collection_class'           => $details->collectionClass,
+                'service_name'               => $details->serviceName,
             ),
         ));
         $this->configResource->patch($config, true);


### PR DESCRIPTION
this fix adds the missing index `service_name` in `zf-rest` controller configuration, when a rest service is created or modified via api admin.
if `service_name` is missing, the module documentation is never shown