### PR TITLE
Remove QueryBuilder from DoctrineResourceEvents; add ObjectManager

### DIFF
--- a/src/Server/Event/DoctrineResourceEvent.php
+++ b/src/Server/Event/DoctrineResourceEvent.php
@@ -44,26 +44,26 @@ class DoctrineResourceEvent extends Event
     protected $collection;
 
     /**
-     * @var Doctrine\ORM\QueryBuilder
+     * @var object
      */
-    protected $queryBuilder;
+    protected $objectManager;
 
     /**
-     * @param Doctrine\ORM\QueryBuilder $queryBuilder
+     * @param object
      */
-    public function setQueryBuilder($queryBuilder)
+    public function setObjectManager($objectManager)
     {
-        $this->queryBuilder = $queryBuilder;
+        $this->objectManager = $objectManager;
 
         return $this;
     }
 
     /**
-     * @return Doctrine\ORM\QueryBuilder
+     * @return object
      */
-    public function getQueryBuilder()
+    public function getObjectManager()
     {
-        return $this->queryBuilder;
+        return $this->objectManager;
     }
 
     /**

--- a/src/Server/Resource/DoctrineResource.php
+++ b/src/Server/Resource/DoctrineResource.php
@@ -312,11 +312,13 @@ class DoctrineResource extends AbstractResourceListener implements
         }
 
         $this->getObjectManager()->persist($entity);
-        $this->getObjectManager()->flush();
+
         $results = $this->triggerDoctrineEvent(DoctrineResourceEvent::EVENT_CREATE_POST, $entity);
         if ($results->last() instanceof ApiProblem) {
             return $results->last();
         }
+
+        $this->getObjectManager()->flush();
 
         return $entity;
     }
@@ -343,12 +345,13 @@ class DoctrineResource extends AbstractResourceListener implements
         }
 
         $this->getObjectManager()->remove($entity);
-        $this->getObjectManager()->flush();
 
         $results = $this->triggerDoctrineEvent(DoctrineResourceEvent::EVENT_DELETE_POST, $entity);
         if ($results->last() instanceof ApiProblem) {
             return $results->last();
         }
+
+        $this->getObjectManager()->flush();
 
         return true;
     }
@@ -545,19 +548,20 @@ class DoctrineResource extends AbstractResourceListener implements
         }
             // @codeCoverageIgnoreEnd
 
-        // Hydrate entity with patched data
-        $this->getHydrator()->hydrate((array) $data, $entity);
-
         $results = $this->triggerDoctrineEvent(DoctrineResourceEvent::EVENT_PATCH_PRE, $entity);
         if ($results->last() instanceof ApiProblem) {
             return $results->last();
         }
 
-        $this->getObjectManager()->flush();
+        // Hydrate entity with patched data
+        $this->getHydrator()->hydrate((array) $data, $entity);
+
         $results = $this->triggerDoctrineEvent(DoctrineResourceEvent::EVENT_PATCH_POST, $entity);
         if ($results->last() instanceof ApiProblem) {
             return $results->last();
         }
+
+        $this->getObjectManager()->flush();
 
         return $entity;
     }
@@ -591,18 +595,19 @@ class DoctrineResource extends AbstractResourceListener implements
         }
             // @codeCoverageIgnoreEnd
 
-        $this->getHydrator()->hydrate((array) $data, $entity);
-
         $results = $this->triggerDoctrineEvent(DoctrineResourceEvent::EVENT_UPDATE_PRE, $entity);
         if ($results->last() instanceof ApiProblem) {
             return $results->last();
         }
 
-        $this->getObjectManager()->flush();
+        $this->getHydrator()->hydrate((array) $data, $entity);
+
         $results = $this->triggerDoctrineEvent(DoctrineResourceEvent::EVENT_UPDATE_POST, $entity);
         if ($results->last() instanceof ApiProblem) {
             return $results->last();
         }
+
+        $this->getObjectManager()->flush();
 
         return $entity;
     }

--- a/src/Server/Resource/DoctrineResource.php
+++ b/src/Server/Resource/DoctrineResource.php
@@ -475,13 +475,11 @@ class DoctrineResource extends AbstractResourceListener implements
         }
             // @codeCoverageIgnoreEnd
 
-        // Run fetch all pre with query builder
-        $event = new DoctrineResourceEvent(DoctrineResourceEvent::EVENT_FETCH_ALL_PRE, $this);
-        $event->setQueryBuilder($queryBuilder);
-        $event->setResourceEvent($this->getEvent());
-        $event->setEntity($this->getEntityClass());
-        $eventManager = $this->getEventManager();
-        $response = $eventManager->trigger($event);
+        $response = $this->triggerDoctrineEvent(
+            DoctrineResourceEvent::EVENT_FETCH_ALL_PRE,
+            $this->getEntityClass(),
+            null
+        );
         if ($response->last() instanceof ApiProblem) {
             return $response->last();
         }
@@ -490,7 +488,11 @@ class DoctrineResource extends AbstractResourceListener implements
         $reflection = new \ReflectionClass($this->getCollectionClass());
         $collection = $reflection->newInstance($adapter);
 
-        $results = $this->triggerDoctrineEvent(DoctrineResourceEvent::EVENT_FETCH_ALL_POST, null, $collection);
+        $results = $this->triggerDoctrineEvent(
+            DoctrineResourceEvent::EVENT_FETCH_ALL_POST,
+            $this->getEntityClass(),
+            $collection
+        );
         if ($results->last() instanceof ApiProblem) {
             return $results->last();
         }
@@ -621,6 +623,7 @@ class DoctrineResource extends AbstractResourceListener implements
         $event = new DoctrineResourceEvent($name, $this);
         $event->setEntity($entity);
         $event->setCollection($collection);
+        $event->setObjectManager($this->getObjectManager());
         $event->setResourceEvent($this->getEvent());
 
         $eventManager = $this->getEventManager();


### PR DESCRIPTION
Doctrine Resource Events do not affect the QueryBuilder when set.  This is a fix for legacy code from before QueryProviders and QueryCreateFilters.  Doctrine Resource Events now contain the objectManager instead of the QueryBuilder which didn't do anything for the developer.