### PR TITLE
Fixed DoctrineResource::findEntity() criteria #171

### DIFF
--- a/src/Server/Resource/DoctrineResource.php
+++ b/src/Server/Resource/DoctrineResource.php
@@ -693,18 +693,14 @@ class DoctrineResource extends AbstractResourceListener implements
         }
 
         foreach ($routeParams as $routeMatchParam => $value) {
-            $stripped = false;
             if ($this->getStripRouteParameterSuffix() === substr(
                 $routeMatchParam,
                 -1 * strlen($this->getStripRouteParameterSuffix())
             )) {
                 $routeMatchParam = substr($routeMatchParam, 0, -1 * strlen($this->getStripRouteParameterSuffix()));
-                $stripped = true;
             }
 
-            if (in_array($routeMatchParam, $associationMappings)
-                || (!$stripped && in_array($routeMatchParam, $fieldNames))
-            ) {
+            if (in_array($routeMatchParam, $associationMappings) || in_array($routeMatchParam, $fieldNames)) {
                 $criteria[$routeMatchParam] = $value;
             }
         }

--- a/src/Server/Resource/DoctrineResource.php
+++ b/src/Server/Resource/DoctrineResource.php
@@ -175,7 +175,7 @@ class DoctrineResource extends AbstractResourceListener implements
     }
 
     /**
-     * @var entityIdentifierName string
+     * @var string
      */
     protected $entityIdentifierName;
 
@@ -188,12 +188,36 @@ class DoctrineResource extends AbstractResourceListener implements
     }
 
     /**
-     * @param ZF\Apigility\Doctrine\Server\Query\Provider\QueryProviderInterface
+     * @param string $value
+     * @return $this
      */
     public function setEntityIdentifierName($value)
     {
         $this->entityIdentifierName = $value;
 
+        return $this;
+    }
+
+    /**
+     * @var string
+     */
+    protected $routeIdentifierName;
+
+    /**
+     * @return string
+     */
+    public function getRouteIdentifierName()
+    {
+        return $this->routeIdentifierName;
+    }
+
+    /**
+     * @param string $routeIdentifierName
+     * @return $this
+     */
+    public function setRouteIdentifierName($routeIdentifierName)
+    {
+        $this->routeIdentifierName = $routeIdentifierName;
         return $this;
     }
 
@@ -660,18 +684,20 @@ class DoctrineResource extends AbstractResourceListener implements
         $routeMatch = $this->getEvent()->getRouteMatch();
         $associationMappings = $classMetaData->getAssociationNames();
         $fieldNames = $classMetaData->getFieldNames();
+        $routeParams = $routeMatch->getParams();
 
-        foreach ($routeMatch->getParams() as $routeMatchParam => $value) {
+        if (array_key_exists($this->getRouteIdentifierName(), $routeParams)) {
+            unset($routeParams[$this->getRouteIdentifierName()]);
+        }
+
+        foreach ($routeParams as $routeMatchParam => $value) {
             $stripped = false;
-            if (substr(
-                $routeMatchParam,
-                (-1 * abs(strlen($this->getStripRouteParameterSuffix())) == $this->getStripRouteParameterSuffix())
-            )) {
-                $routeMatchParam = substr(
+            if ($this->getStripRouteParameterSuffix() === substr(
                     $routeMatchParam,
-                    0,
-                    strlen($routeMatchParam) - strlen($this->getStripRouteParameterSuffix())
-                );
+                    -1 * strlen($this->getStripRouteParameterSuffix())
+                )
+            ) {
+                $routeMatchParam = substr($routeMatchParam, 0, -1 * strlen($this->getStripRouteParameterSuffix()));
                 $stripped = true;
             }
 

--- a/src/Server/Resource/DoctrineResource.php
+++ b/src/Server/Resource/DoctrineResource.php
@@ -693,10 +693,9 @@ class DoctrineResource extends AbstractResourceListener implements
         foreach ($routeParams as $routeMatchParam => $value) {
             $stripped = false;
             if ($this->getStripRouteParameterSuffix() === substr(
-                    $routeMatchParam,
-                    -1 * strlen($this->getStripRouteParameterSuffix())
-                )
-            ) {
+                $routeMatchParam,
+                -1 * strlen($this->getStripRouteParameterSuffix())
+            )) {
                 $routeMatchParam = substr($routeMatchParam, 0, -1 * strlen($this->getStripRouteParameterSuffix()));
                 $stripped = true;
             }

--- a/src/Server/Resource/DoctrineResource.php
+++ b/src/Server/Resource/DoctrineResource.php
@@ -662,6 +662,7 @@ class DoctrineResource extends AbstractResourceListener implements
         $fieldNames = $classMetaData->getFieldNames();
 
         foreach ($routeMatch->getParams() as $routeMatchParam => $value) {
+            $stripped = false;
             if (substr(
                 $routeMatchParam,
                 (-1 * abs(strlen($this->getStripRouteParameterSuffix())) == $this->getStripRouteParameterSuffix())
@@ -671,10 +672,11 @@ class DoctrineResource extends AbstractResourceListener implements
                     0,
                     strlen($routeMatchParam) - strlen($this->getStripRouteParameterSuffix())
                 );
+                $stripped = true;
             }
 
             if (in_array($routeMatchParam, $associationMappings)
-                or in_array($routeMatchParam, $fieldNames)
+                || (!$stripped && in_array($routeMatchParam, $fieldNames))
             ) {
                 $criteria[$routeMatchParam] = $value;
             }

--- a/src/Server/Resource/DoctrineResourceFactory.php
+++ b/src/Server/Resource/DoctrineResourceFactory.php
@@ -109,11 +109,16 @@ class DoctrineResourceFactory implements AbstractFactoryInterface
         $config = $serviceLocator->get('Config');
         $doctrineConnectedConfig = $config['zf-apigility']['doctrine-connected'][$requestedName];
 
+        $restConfig = null;
         foreach ($config['zf-rest'] as $restControllerConfig) {
             if ($restControllerConfig['listener'] == $requestedName) {
                 $restConfig = $restControllerConfig;
                 break;
             }
+        }
+
+        if (null === $restConfig) {
+            throw new \RuntimeException(sprintf('No zf-rest configuration found for resource %s', $requestedName));
         }
 
         $className = isset($doctrineConnectedConfig['class']) ? $doctrineConnectedConfig['class'] : $requestedName;
@@ -125,6 +130,7 @@ class DoctrineResourceFactory implements AbstractFactoryInterface
         $queryCreateFilter = $this->loadQueryCreateFilter($serviceLocator, $doctrineConnectedConfig, $objectManager);
         $configuredListeners = $this->loadConfiguredListeners($serviceLocator, $doctrineConnectedConfig);
 
+        /** @var DoctrineResource $listener */
         $listener = new $className();
         $listener->setObjectManager($objectManager);
         $listener->setHydrator($hydrator);
@@ -132,6 +138,7 @@ class DoctrineResourceFactory implements AbstractFactoryInterface
         $listener->setQueryCreateFilter($queryCreateFilter);
         $listener->setServiceManager($serviceLocator);
         $listener->setEntityIdentifierName($restConfig['entity_identifier_name']);
+        $listener->setRouteIdentifierName($restConfig['route_identifier_name']);
         if (count($configuredListeners)) {
             foreach ($configuredListeners as $configuredListener) {
                 $listener->getEventManager()->attach($configuredListener);

--- a/test/assets/module/DbOriginal/config/xml/ZFTestApigilityDb.Entity.Album.dcm.xml
+++ b/test/assets/module/DbOriginal/config/xml/ZFTestApigilityDb.Entity.Album.dcm.xml
@@ -11,5 +11,10 @@
         <join-column name="artist_id" referenced-column-name="id"/>
       </join-columns>
     </many-to-one>
+    <many-to-one field="album" target-entity="ZFTestApigilityDb\Entity\Album">
+      <join-columns>
+        <join-column name="album_id" referenced-column-name="id" nullable="true"/>
+      </join-columns>
+    </many-to-one>
   </entity>
 </doctrine-mapping>

--- a/test/assets/module/DbOriginal/src/ZFTestApigilityDb/Entity/Album.php
+++ b/test/assets/module/DbOriginal/src/ZFTestApigilityDb/Entity/Album.php
@@ -52,4 +52,31 @@ class Album
 
         return $this;
     }
+
+    protected $album;
+
+    /**
+     * Parent Album
+     *
+     * @return null|Album
+     */
+    public function getAlbum()
+    {
+        return $this->album;
+    }
+
+    /**
+     * Parent Album
+     *
+     * @param null|Album $album
+     * @return $this
+     */
+    public function setAlbum($album)
+    {
+        if (null !== $album && !$album instanceof Album) {
+            throw new \InvalidArgumentException('Invalid album argument');
+        }
+        $this->album = $album;
+        return $this;
+    }
 }

--- a/test/src/Server/ORM/Setup/ApigilityTest.php
+++ b/test/src/Server/ORM/Setup/ApigilityTest.php
@@ -36,7 +36,7 @@ class ApigilityTest extends \Zend\Test\PHPUnit\Controller\AbstractHttpController
             "entityClass" => "ZFTestApigilityDb\\Entity\\Artist",
             "routeIdentifierName" => "artist_id",
             "entityIdentifierName" => "id",
-            "routeMatch" => "/test/artist",
+            "routeMatch" => "/test/rest/artist",
             "collectionHttpMethods" => array(
                 0 => 'GET',
                 1 => 'POST',
@@ -51,19 +51,20 @@ class ApigilityTest extends \Zend\Test\PHPUnit\Controller\AbstractHttpController
             "entityClass" => "ZFTestApigilityDb\\Entity\\Artist",
             "routeIdentifierName" => "artist_name",
             "entityIdentifierName" => "name",
-            "routeMatch" => "/test/artist-by-name",
+            "routeMatch" => "/test/rest/artist-by-name",
             "collectionHttpMethods" => array(
                 0 => 'GET',
             ),
         );
 
+        // This route is what should be an rpc service, but an user could do
         $albumResourceDefinition = array(
             "objectManager"=> "doctrine.entitymanager.orm_default",
             "serviceName" => "Album",
             "entityClass" => "ZFTestApigilityDb\\Entity\\Album",
             "routeIdentifierName" => "album_id",
             "entityIdentifierName" => "id",
-            "routeMatch" => "/test/album",
+            "routeMatch" => "/test/rest[/artist/:artist_id]/album[/:album_id]",
             "collectionHttpMethods" => array(
                 0 => 'GET',
                 1 => 'POST',


### PR DESCRIPTION
Related to issue #171

If the route parameter was stripped off of ```stripRouteParameterSuffix```, it will not be added in the criteria if match in ```$fieldNames```.