### PR TITLE
Only call setOAuth2Server if the method exists in the provider

### DIFF
--- a/src/Server/Resource/DoctrineResourceFactory.php
+++ b/src/Server/Resource/DoctrineResourceFactory.php
@@ -274,7 +274,7 @@ class DoctrineResourceFactory implements AbstractFactoryInterface
         // Set object manager for all query providers
         foreach ($queryProviders as $provider) {
             $provider->setObjectManager($objectManager);
-            if ($oAuth2Server) {
+            if ($oAuth2Server && method_exists($provider, 'setOAuth2Server')) {
                 $provider->setOAuth2Server($oAuth2Server);
             }
         }


### PR DESCRIPTION
The setOAuth2Server method is not a part of the ```ZF\Apigility\Doctrine\Server\Query\Provider\QueryProviderInterface``` and should not always be set. The new ```ZF\Doctrine\QueryBuilder\Query\Provider\DefaultOrm``` class does not have this method, so at the moment an exception occurs.