### PR TITLE
Re-add ServiceManager (fix BC break)

### DIFF
--- a/src/Server/Resource/DoctrineResource.php
+++ b/src/Server/Resource/DoctrineResource.php
@@ -2,6 +2,8 @@
 
 namespace ZF\Apigility\Doctrine\Server\Resource;
 
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\ServiceManagerAwareInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManagerInterface;
@@ -32,10 +34,36 @@ use ReflectionClass;
  * @package ZF\Apigility\Doctrine\Server\Resource
  */
 class DoctrineResource extends AbstractResourceListener implements
+    ServiceManagerAwareInterface,
     ObjectManagerAwareInterface,
     EventManagerAwareInterface,
     HydratorAwareInterface
 {
+    /**
+     * @var ServiceManager
+     */
+    protected $serviceManager;
+
+    /**
+     * @param ServiceManager $serviceManager
+     *
+     * @return $this
+     */
+    public function setServiceManager(ServiceManager $serviceManager)
+    {
+        $this->serviceManager = $serviceManager;
+
+        return $this;
+    }
+
+    /**
+     * @return ServiceManager
+     */
+    public function getServiceManager()
+    {
+        return $this->serviceManager;
+    }
+
     /**
      * @var EventManagerInterface
      */

--- a/src/Server/Resource/DoctrineResourceFactory.php
+++ b/src/Server/Resource/DoctrineResourceFactory.php
@@ -136,6 +136,7 @@ class DoctrineResourceFactory implements AbstractFactoryInterface
 
         /** @var DoctrineResource $listener */
         $listener = new $className();
+        $listener->setServiceManager($serviceLocator);
         $listener->setObjectManager($objectManager);
         $listener->setHydrator($hydrator);
         $listener->setQueryProviders($queryProviders);


### PR DESCRIPTION
In commit https://github.com/zfcampus/zf-apigility-doctrine/commit/0e49889573e8f5631b956da1849b3fda861859ad I removed the ServiceManger from the DoctrineResource.  This was done in the spirit of tidying the class.  However it caused a BC break for users expecting the ServiceManger when extending the class ancestors.

This commit fixes the BC break reported here https://github.com/zfcampus/zf-apigility-doctrine/commit/0e49889573e8f5631b956da1849b3fda861859ad#commitcomment-12049598

