### PR TITLE
Reduction requirements for doctrine-orm-module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "doctrine/doctrine-mongo-odm-module": "^0.8.0",
-        "doctrine/doctrine-orm-module": "^0.8.0",
+        "doctrine/doctrine-orm-module": "~0.8.0",
         "doctrine/mongodb-odm": "~1.0.0@beta",
         "phpunit/phpunit": "~4.7",
         "squizlabs/php_codesniffer": "^2.3.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "doctrine/doctrine-mongo-odm-module": "^0.8.0",
-        "doctrine/doctrine-orm-module": "~0.8.0",
+        "doctrine/doctrine-orm-module": "~0.8",
         "doctrine/mongodb-odm": "~1.0.0@beta",
         "phpunit/phpunit": "~4.7",
         "squizlabs/php_codesniffer": "^2.3.0",


### PR DESCRIPTION
Why are you don't use last 0.9 version doctrine-orm-module? Any reasons?
If my application will require v0.9 in composer, then I can not install zf-apigility-doctrine.

By the way phpro/zf-doctrine-hydration-module already required doctrine-orm-module dependency with any versions "*". 
 