### PR TITLE
fixed wrong timezone case raising php notice

### DIFF
--- a/test/Bootstrap.php
+++ b/test/Bootstrap.php
@@ -11,7 +11,7 @@ use RuntimeException;
 
 error_reporting(E_ALL | E_STRICT);
 chdir(__DIR__);
-date_default_timezone_set('utc');
+date_default_timezone_set('UTC');
 
 /**
  * Test bootstrap, for setting up autoloading


### PR DESCRIPTION
Fixed wrong case for timezone raising a PHP notice:

```
PHP Notice:  date_default_timezone_set(): Timezone ID 'utc' is invalid in apigility-doctrine/test/Bootstrap.php on line 14
```
