### PR TITLE
Fixed typo in InvalidArgumentExcpetion

### DIFF
--- a/src/Server/Exception/InvalidArgumentException.php
+++ b/src/Server/Exception/InvalidArgumentException.php
@@ -2,7 +2,7 @@
 
 namespace ZF\Apigility\Doctrine\Server\Exception;
 
-use InvalidArgumentExcpetion as PHPInvalidArgumentException;
+use InvalidArgumentException as PHPInvalidArgumentException;
 
 /**
  * Class InvalidArgumentException


### PR DESCRIPTION
Fixing a typo in the parent class name being aliased. Should obviously be `Exception` instead of `Excpetion`.