### PR TITLE
Some route parameters should be restricted in doctrine resource.

### DIFF
--- a/src/Server/Resource/DoctrineResource.php
+++ b/src/Server/Resource/DoctrineResource.php
@@ -752,8 +752,16 @@ class DoctrineResource extends AbstractResourceListener implements
         if (array_key_exists($this->getRouteIdentifierName(), $routeParams)) {
             unset($routeParams[$this->getRouteIdentifierName()]);
         }
-
-        foreach ($routeParams as $routeMatchParam => $value) {
+        
+        $reservedRouteParams = ['controller','action',
+            \Zend\Mvc\ModuleRouteListener::MODULE_NAMESPACE,\Zend\Mvc\ModuleRouteListener::ORIGINAL_CONTROLLER
+        ];
+        $allowedRouteParams = array_diff_key($routeParams, array_flip( $reservedRouteParams ) );
+        
+        /**
+         * Append query selection parameters by route match.
+         */
+        foreach ($allowedRouteParams as $routeMatchParam => $value) {
             if ($this->getStripRouteParameterSuffix() === substr(
                 $routeMatchParam,
                 -1 * strlen($this->getStripRouteParameterSuffix())
@@ -769,7 +777,7 @@ class DoctrineResource extends AbstractResourceListener implements
         // Build query
         $queryProvider = $this->getQueryProvider($method);
         $queryBuilder = $queryProvider->createQuery($this->getEvent(), $this->getEntityClass(), null);
-
+        
         if ($queryBuilder instanceof ApiProblem) {
             // @codeCoverageIgnoreStart
             return $queryBuilder;


### PR DESCRIPTION
In my case I have document, that contains `action ` property. So it came under this filtering functionality.
( action => false) 
I've decided, that it is better to use ony non dispatch dependant parameters in this additional filtering functionality. 