### PR TITLE
Support per-resource hydrators

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "zendframework/zend-log": "^2.5.0",
         "zendframework/zend-serializer": "^2.5.0",
         "zendframework/zend-test": "^2.5.0",
+        "zendframework/zend-hydrator": "~1",
         "zfcampus/zf-apigility-admin": "^1.1",
         "zendframework/zend-i18n": "^2.5.0"
     },

--- a/src/Server/Resource/DoctrineResourceFactory.php
+++ b/src/Server/Resource/DoctrineResourceFactory.php
@@ -108,6 +108,7 @@ class DoctrineResourceFactory implements AbstractFactoryInterface
     {
         $config = $serviceLocator->get('Config');
         $doctrineConnectedConfig = $config['zf-apigility']['doctrine-connected'][$requestedName];
+        $doctrineHydratorConfig = $config['doctrine-hydrator'];
 
         $restConfig = null;
         foreach ($config['zf-rest'] as $restControllerConfig) {
@@ -129,7 +130,7 @@ class DoctrineResourceFactory implements AbstractFactoryInterface
         $className = $this->normalizeClassname($className);
 
         $objectManager = $this->loadObjectManager($serviceLocator, $doctrineConnectedConfig);
-        $hydrator = $this->loadHydrator($serviceLocator, $doctrineConnectedConfig, $objectManager);
+        $hydrator = $this->loadHydrator($serviceLocator, $doctrineConnectedConfig, $doctrineHydratorConfig, $objectManager);
         $queryProviders = $this->loadQueryProviders($serviceLocator, $doctrineConnectedConfig, $objectManager);
         $queryCreateFilter = $this->loadQueryCreateFilter($serviceLocator, $doctrineConnectedConfig, $objectManager);
         $configuredListeners = $this->loadConfiguredListeners($serviceLocator, $doctrineConnectedConfig);
@@ -187,10 +188,14 @@ class DoctrineResourceFactory implements AbstractFactoryInterface
      *
      * @return HydratorInterface
      */
-    protected function loadHydrator(ServiceLocatorInterface $serviceLocator, $config)
+    protected function loadHydrator(
+        ServiceLocatorInterface $serviceLocator,
+        array $doctrineConnectedConfig,
+        array $doctrineHydratorConfig,
+        $objectManager)
     {
         // @codeCoverageIgnoreStart
-        if (!isset($config['hydrator'])) {
+        if (!isset($doctrineConnectedConfig['hydrator'])) {
             return null;
         }
 
@@ -199,11 +204,22 @@ class DoctrineResourceFactory implements AbstractFactoryInterface
         }
 
         $hydratorManager = $serviceLocator->get('HydratorManager');
-        if (!$hydratorManager->has($config['hydrator'])) {
+        if (!$hydratorManager->has($doctrineConnectedConfig['hydrator'])) {
             return null;
         }
+
+        // Set the hydrator for the entity for this resource to the hydrator
+        // configured for the resource.  This removes per-entity hydrator configuration
+        // allowing multiple hydrators per resource.
+        if (isset($doctrineConnectedConfig['hydrator'])) {
+            $entityClass = $doctrineHydratorConfig[$doctrineConnectedConfig['hydrator']]['entity_class'];
+            $viewHelpers  = $serviceLocator->get('ViewHelperManager');
+            $hal = $viewHelpers->get('Hal');
+            $hal->getEntityHydratorManager()->addHydrator($entityClass, $doctrineConnectedConfig['hydrator']);
+        }
+
         // @codeCoverageIgnoreEnd
-        return $hydratorManager->get($config['hydrator']);
+        return $hydratorManager->get($doctrineConnectedConfig['hydrator']);
     }
 
     /**

--- a/src/Server/Resource/DoctrineResourceFactory.php
+++ b/src/Server/Resource/DoctrineResourceFactory.php
@@ -130,7 +130,12 @@ class DoctrineResourceFactory implements AbstractFactoryInterface
         $className = $this->normalizeClassname($className);
 
         $objectManager = $this->loadObjectManager($serviceLocator, $doctrineConnectedConfig);
-        $hydrator = $this->loadHydrator($serviceLocator, $doctrineConnectedConfig, $doctrineHydratorConfig, $objectManager);
+        $hydrator = $this->loadHydrator(
+            $serviceLocator,
+            $doctrineConnectedConfig,
+            $doctrineHydratorConfig,
+            $objectManager
+        );
         $queryProviders = $this->loadQueryProviders($serviceLocator, $doctrineConnectedConfig, $objectManager);
         $queryCreateFilter = $this->loadQueryCreateFilter($serviceLocator, $doctrineConnectedConfig, $objectManager);
         $configuredListeners = $this->loadConfiguredListeners($serviceLocator, $doctrineConnectedConfig);
@@ -192,8 +197,9 @@ class DoctrineResourceFactory implements AbstractFactoryInterface
         ServiceLocatorInterface $serviceLocator,
         array $doctrineConnectedConfig,
         array $doctrineHydratorConfig,
-        $objectManager)
-    {
+        $objectManager
+    ) {
+
         // @codeCoverageIgnoreStart
         if (!isset($doctrineConnectedConfig['hydrator'])) {
             return null;


### PR DESCRIPTION
Because each resource defines it's own hydrator that hydrator should be used to hydrate the entity for the resource.  Currently the entity is hydrated with the hydrator configured for the entity.  Because of this you cannot use different hydrators for different api resources.  I'm adding a patch to the DoctrineResourceFactory to change the entity hydrator to the hydrator configured for the resource.