### PR TITLE
inject service locator into DoctrineAutodiscoveryModel

### DIFF
--- a/src/Admin/Module.php
+++ b/src/Admin/Module.php
@@ -68,8 +68,9 @@ class Module implements
                         // @codeCoverageIgnoreEnd
                     }
                     $config = $services->get('Config');
-
-                    return new Model\DoctrineAutodiscoveryModel($config);
+                    $model= new Model\DoctrineAutodiscoveryModel($config);
+                    $model->setServiceLocator($services);
+                    return $model;
                 },
                 'ZF\Apigility\Doctrine\Admin\Model\DoctrineRestServiceModelFactory' => function ($services) {
                     if (!$services->has('ZF\Apigility\Admin\Model\ModulePathSpec')


### PR DESCRIPTION
DoctrineAutodiscoveryModel extends AbstractAutodiscoveryModel which is dependent on the root service locator for the moduleHasService call therefore that must be injected into any class extending this abstract.
#261 