### PR TITLE
Optional Entity Factories

### DIFF
--- a/src/Server/Resource/DoctrineResource.php
+++ b/src/Server/Resource/DoctrineResource.php
@@ -12,6 +12,7 @@ use DoctrineModule\Stdlib\Hydrator;
 use Zend\EventManager\EventInterface;
 use ZF\Apigility\Doctrine\Server\Event\DoctrineResourceEvent;
 use ZF\Apigility\Doctrine\Server\Query\Provider\QueryProviderInterface;
+use ZF\Apigility\Doctrine\Server\Resource\EntityFactory\EntityFactoryInterface;
 use ZF\ApiProblem\ApiProblem;
 use ZF\Apigility\Doctrine\Server\Exception\InvalidArgumentException;
 use ZF\Apigility\Doctrine\Server\Query\CreateFilter\QueryCreateFilterInterface;
@@ -303,9 +304,10 @@ class DoctrineResource extends AbstractResourceListener implements
      * Create a resource
      *
      * @param  mixed $data
-     * @return ApiProblem|mixed
+     * @param EntityFactoryInterface $entityFactory A factory to delegate instantiation of the entity
+     * @return mixed|ApiProblem
      */
-    public function create($data)
+    public function create($data, EntityFactoryInterface $entityFactory = null)
     {
         $entityClass = $this->getEntityClass();
 
@@ -314,7 +316,7 @@ class DoctrineResource extends AbstractResourceListener implements
             return $data;
         }
 
-        $entity = new $entityClass;
+        $entity = $entityFactory ? $entityFactory->createEntity($data) : new $entityClass;
         $results = $this->triggerDoctrineEvent(DoctrineResourceEvent::EVENT_CREATE_PRE, $entity, $data);
         if ($results->last() instanceof ApiProblem) {
             return $results->last();

--- a/src/Server/Resource/EntityFactory/DisabledConstructorEntityFactory.php
+++ b/src/Server/Resource/EntityFactory/DisabledConstructorEntityFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace ZF\Apigility\Doctrine\Server\Resource\EntityFactory;
+
+/**
+ * Creates an entity class using reflection to disable the class constructor
+ */
+final class DisabledConstructorEntityFactory implements EntityFactoryInterface
+{
+    /**
+     * Creates a Doctrine entity
+     *
+     * @param string $entityClass
+     * @param array $data Request data before DoctrineResourceEvent is triggered.
+     * @return object
+     */
+    public function createEntity($entityClass, $data = [])
+    {
+        $reflectionClass = new \ReflectionClass($entityClass);
+        // do nothing with $data
+
+        return $reflectionClass->newInstanceWithoutConstructor();
+    }
+}

--- a/src/Server/Resource/EntityFactory/DisabledConstructorEntityFactory.php
+++ b/src/Server/Resource/EntityFactory/DisabledConstructorEntityFactory.php
@@ -10,7 +10,7 @@ final class DisabledConstructorEntityFactory implements EntityFactoryInterface
     /**
      * Creates a Doctrine entity
      *
-     * @param string $entityClass
+     * @param string|object $entityClass
      * @param array $data Request data before DoctrineResourceEvent is triggered.
      * @return object
      */

--- a/src/Server/Resource/EntityFactory/EntityFactoryInterface.php
+++ b/src/Server/Resource/EntityFactory/EntityFactoryInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace ZF\Apigility\Doctrine\Server\Resource\EntityFactory;
+
+/**
+ * Defines a factory that creates Doctrine entity instances on behalf of DoctrineResource
+ */
+interface EntityFactoryInterface
+{
+    /**
+     * Creates a Doctrine entity
+     *
+     * @param string $entityClass
+     * @param array $data Request data before DoctrineResourceEvent is triggered (caution!).
+     * @return object
+     */
+    public function createEntity($entityClass, $data = []);
+}


### PR DESCRIPTION
Add optional use of entity factories to instantiate entities in the `create()` method.

Use case: I'm working on a project that uses a constructor on Doctrine entity classes to make sure they're instantiated using the minimum required data. I can't change that at the moment because several other applications use the same Doctrine entities.

So I have to bypass that in Apigility: I want to be able to instantiate those classes without the constructor. Hence this PR and the existence of `DisabledConstructorEntityFactory.php`.

I can add unit tests once we discuss if this is a good way of addressing the problem.