### PR TITLE
Add zf-hal as a development requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
         "zendframework/zend-serializer": "^2.8",
         "zendframework/zend-test": "^2.6.1 || ^3.0.1",
         "zendframework/zend-stdlib": "^2.7.7 || ^3.0.1",
+        "zfcampus/zf-hal": "^1.4.2",
         "zfcampus/zf-apigility-admin": "^1.5.7"
     },
     "suggest": {


### PR DESCRIPTION
When running composer with `--prefer-lowest` and an empty `vendor/` directory, an error occurs. This is due to the fact that while zf-apigility-admin requires zf-hal 1.4.2 or up, it is a *development* requirement. However, zf-apigility is a *production* requirement, and the 1.3 version specified requires zf-hal 1.4.1 or up. As a result, composer determines that there is a conflict, and the lower, 1.4.1 version of zf-hal will not satisfy the requirements of zf-apigility-admin, and thus fails.

Adding zf-hal as a development requirement, and pinning it to version 1.4.2, solves the issue.