### PR TITLE
Fixes usage of zf hydrators

### DIFF
--- a/src/Server/Resource/DoctrineResource.php
+++ b/src/Server/Resource/DoctrineResource.php
@@ -23,8 +23,8 @@ use Zend\EventManager\EventManagerAwareInterface;
 use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\StaticEventManager;
 use Zend\Stdlib\ArrayUtils;
-use Zend\Stdlib\Hydrator\HydratorAwareInterface;
-use Zend\Stdlib\Hydrator\HydratorInterface;
+use Zend\Hydrator\HydratorAwareInterface;
+use Zend\Hydrator\HydratorInterface;
 use Traversable;
 use ReflectionClass;
 


### PR DESCRIPTION
Since this package is using zend/hydrator to load hydrators the interfaces
should be used from that package and not from the legacy stdlib hydrators.

This should be an hotfix on version 1.1.1 I'm no sure how this should be accomplished. I cannot create a PR to the right version.
