### PR TITLE
pass field type to $queryBuilder->setParameter()

### DIFF
--- a/src/Server/Resource/DoctrineResource.php
+++ b/src/Server/Resource/DoctrineResource.php
@@ -731,7 +731,7 @@ class DoctrineResource extends AbstractResourceListener implements
             } else {
                 $parameterName = 'a' . md5(rand());
                 $queryBuilder->andwhere($queryBuilder->expr()->eq('row.' . $key, ":$parameterName"));
-                $queryBuilder->setParameter($parameterName, $value);
+                $queryBuilder->setParameter($parameterName, $value, $classMetaData->getTypeOfField($key));
             }
         }
 

--- a/test/assets/module/ZFTestApigilityDb/config/xml/ZFTestApigilityDb.Entity.Product.dcm.xml
+++ b/test/assets/module/ZFTestApigilityDb/config/xml/ZFTestApigilityDb.Entity.Product.dcm.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xsi="http://www.w3.org/2001/XMLSchema-instance" schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+  <entity name="ZFTestApigilityDb\Entity\Product">
+    <id name="id" type="rev">
+      <generator strategy="CUSTOM"/>
+      <custom-id-generator class="ZFTestApigilityDb\Type\RevGenerator"/>
+    </id>
+  </entity>
+</doctrine-mapping>

--- a/test/assets/module/ZFTestApigilityDb/src/ZFTestApigilityDb/Entity/Product.php
+++ b/test/assets/module/ZFTestApigilityDb/src/ZFTestApigilityDb/Entity/Product.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ZFTestApigilityDb\Entity;
+
+class Product
+{
+    protected $id;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/test/assets/module/ZFTestApigilityDb/src/ZFTestApigilityDb/Type/RevGenerator.php
+++ b/test/assets/module/ZFTestApigilityDb/src/ZFTestApigilityDb/Type/RevGenerator.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace ZFTestApigilityDb\Type;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Id\AbstractIdGenerator;
+
+class RevGenerator extends AbstractIdGenerator
+{
+    public function generate(EntityManager $em, $entity)
+    {
+        do {
+            $value = md5(time() . mt_rand());
+        } while ($value === strrev($value));
+
+        return $value;
+    }
+}

--- a/test/assets/module/ZFTestApigilityDb/src/ZFTestApigilityDb/Type/RevType.php
+++ b/test/assets/module/ZFTestApigilityDb/src/ZFTestApigilityDb/Type/RevType.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace ZFTestApigilityDb\Type;
+
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+class RevType extends Type
+{
+    const NAME = 'rev';
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return $platform->getGuidTypeDeclarationSQL($fieldDeclaration);
+    }
+
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        if (! $value) {
+            return null;
+        }
+
+        return strrev($value);
+    }
+
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        if (! $value) {
+            return null;
+        }
+
+        return strrev($value);
+    }
+
+    public function getName()
+    {
+        return static::NAME;
+    }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
+}

--- a/test/config/ORM/local.php
+++ b/test/config/ORM/local.php
@@ -1,8 +1,10 @@
 <?php
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2018 Zend Technologies USA Inc. (http://www.zend.com)
  */
+
+use ZFTestApigilityDb\Type\RevType;
 
 return [
     'doctrine' => [
@@ -13,6 +15,13 @@ return [
                 'driverClass'   => \Doctrine\DBAL\Driver\PDOSqlite\Driver::class,
                 'params' => [
                     'memory' => true,
+                ],
+            ],
+        ],
+        'configuration' => [
+            'orm_default' => [
+                'types' => [
+                    RevType::NAME => RevType::class,
                 ],
             ],
         ],


### PR DESCRIPTION
If you use custom type for identifier (e.g. uuid_binary https://github.com/ramsey/uuid-doctrine) single entity won't be found by id