### PR TITLE
Added "version" to restricted route params - fix #275

### DIFF
--- a/src/Server/Resource/DoctrineResource.php
+++ b/src/Server/Resource/DoctrineResource.php
@@ -707,6 +707,7 @@ class DoctrineResource extends AbstractResourceListener implements
         $reservedRouteParams = [
             'controller',
             'action',
+            'version',
             ModuleRouteListener::MODULE_NAMESPACE,
             ModuleRouteListener::ORIGINAL_CONTROLLER,
         ];

--- a/test/assets/module/ZFTestApigilityDb/config/xml/ZFTestApigilityDb.Entity.Product.dcm.xml
+++ b/test/assets/module/ZFTestApigilityDb/config/xml/ZFTestApigilityDb.Entity.Product.dcm.xml
@@ -5,5 +5,6 @@
       <generator strategy="CUSTOM"/>
       <custom-id-generator class="ZFTestApigilityDb\Type\RevGenerator"/>
     </id>
+    <field name="version" type="string" nullable="true"/>
   </entity>
 </doctrine-mapping>

--- a/test/assets/module/ZFTestApigilityDb/src/ZFTestApigilityDb/Entity/Product.php
+++ b/test/assets/module/ZFTestApigilityDb/src/ZFTestApigilityDb/Entity/Product.php
@@ -6,8 +6,20 @@ class Product
 {
     protected $id;
 
+    protected $version;
+
     public function getId()
     {
         return $this->id;
+    }
+
+    public function getVersion()
+    {
+        return $this->version;
+    }
+
+    public function setVersion($version)
+    {
+        $this->version = $version;
     }
 }

--- a/test/src/Admin/Model/DoctrineAutodiscoveryModelTest.php
+++ b/test/src/Admin/Model/DoctrineAutodiscoveryModelTest.php
@@ -10,6 +10,7 @@ use ZF\Apigility\Doctrine\Admin\Model\DoctrineAutodiscoveryModel;
 use ZFTest\Apigility\Doctrine\TestCase;
 use ZFTestApigilityDb\Entity\Album;
 use ZFTestApigilityDb\Entity\Artist;
+use ZFTestApigilityDb\Entity\Product;
 use ZFTestApigilityDbMongo\Document\Meta;
 
 class DoctrineAutodiscoveryModelTest extends TestCase
@@ -26,15 +27,19 @@ class DoctrineAutodiscoveryModelTest extends TestCase
         $result = $model->fetchFields(null, null, 'doctrine.entitymanager.orm_default');
 
         $this->assertInternalType('array', $result);
-        $this->assertCount(2, $result);
+        $this->assertCount(3, $result);
 
         $this->assertEquals(Album::class, $result[0]['entity_class']);
         $this->assertEquals('Album', $result[0]['service_name']);
         $this->assertCount(2, $result[0]['fields']);
 
-        $this->assertEquals(Artist::class, $result[1]['entity_class']);
-        $this->assertEquals('Artist', $result[1]['service_name']);
-        $this->assertCount(2, $result[1]['fields']);
+        $this->assertEquals(Product::class, $result[1]['entity_class']);
+        $this->assertEquals('Product', $result[1]['service_name']);
+        $this->assertCount(1, $result[1]['fields']);
+
+        $this->assertEquals(Artist::class, $result[2]['entity_class']);
+        $this->assertEquals('Artist', $result[2]['service_name']);
+        $this->assertCount(2, $result[2]['fields']);
     }
 
     public function testODMAutodiscoveryEntitiesWithFields()

--- a/test/src/Server/ORM/CRUD/CRUDTest.php
+++ b/test/src/Server/ORM/CRUD/CRUDTest.php
@@ -259,6 +259,25 @@ class CRUDTest extends TestCase
         ]);
     }
 
+    public function testFetchEntityWithVersionFieldWithVersionParamInPath()
+    {
+        $product = $this->createProduct();
+
+        $this->getRequest()->getHeaders()->addHeaderLine('Accept', 'application/json');
+        $this->getRequest()->setMethod(Request::METHOD_GET);
+
+        $this->dispatch('/v1/test/rest/product/' . $product->getId());
+        $body = json_decode($this->getResponse()->getBody(), true);
+
+        $this->assertResponseStatusCode(200);
+        $this->assertEquals($product->getId(), $body['id']);
+        $this->assertNull($body['version']);
+        $this->validateTriggeredEvents([
+            DoctrineResourceEvent::EVENT_FETCH_PRE,
+            DoctrineResourceEvent::EVENT_FETCH_POST,
+        ]);
+    }
+
     public function testFetchByCustomIdFieldWithInvalidIdValue()
     {
         $product = $this->createProduct();


### PR DESCRIPTION
This is alternative solution, and much simpler than changing parameter name everywhere.
`version` is added to restricted route params (where we have also `controller` and `action`). We can't use this parameter name again.

/cc @jensstalder @TomHAnderson 